### PR TITLE
Replace all dashes and underscores when doing base64UrlDecode

### DIFF
--- a/Modules/common.js
+++ b/Modules/common.js
@@ -60,7 +60,7 @@ function generateCookieVal() {
 //  encoded:    The Base64 URL encoded value
 //  result:     The decoded value
 function base64UrlDecode(encoded) {
-    encoded = encoded.replace('-', '+').replace('_', '/');
+    encoded = encoded.replaceAll('-', '+').replaceAll('_', '/');
     while (encoded.length % 4)
       encoded += '=';
     return base64Decode(encoded);
@@ -78,7 +78,7 @@ function base64Decode(encoded) {
 //  result:     The Base64 URL encoded value
 function base6UurlEncode(unencoded) {
     var encoded = base64Encode(unencoded);
-    return encoded.replace('+', '-').replace('/', '_').replace(/=+$/, '');
+    return encoded.replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
 }
 
 //Function that performs Base64 encoding


### PR DESCRIPTION
This device flow had intermittent failures, giving unknown grant errors.

The reason is that `encoded.replace('-', '+')` only replaces once, while it should replace all occurrences of `-` when encoding/decoding the value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
